### PR TITLE
fix: symbols_to_items not giving fully qualified class name

### DIFF
--- a/lua/laravel/route.lua
+++ b/lua/laravel/route.lua
@@ -94,7 +94,7 @@ M.open = function(route)
   end
 
   local class_location = nil
-  for idx, location in pairs(resp.result) do
+  for _, location in pairs(resp.result) do
     if location.location and
 	location.containerName .. "\\" .. location.name == action[1] and
 	vim.lsp.util._get_symbol_kind_name(location.kind) == "Class" then

--- a/lua/laravel/route.lua
+++ b/lua/laravel/route.lua
@@ -94,9 +94,10 @@ M.open = function(route)
   end
 
   local class_location = nil
-  for idx, location in pairs(locations) do
-    if location.text == string.format("[Class] %s", action[1]) then
-      class_location = locations[idx]
+  for idx, location in pairs(resp.result) do
+    utils.notify("Debug", { msg = vim.inspect(location), level = "INFO" })
+    if location.containerName .. "\\" .. location.name == action[1] then
+      class_location = location
       break
     end
   end
@@ -110,7 +111,7 @@ M.open = function(route)
   end
 
   local command = "edit"
-  local filename = class_location.filename
+  local filename = vim.uri_to_fname(class_location.location.uri)
 
   if vim.api.nvim_buf_get_name(0) ~= filename or command ~= "edit" then
     filename = Path:new(vim.fn.fnameescape(filename)):normalize(vim.loop.cwd())

--- a/lua/laravel/route.lua
+++ b/lua/laravel/route.lua
@@ -95,8 +95,9 @@ M.open = function(route)
 
   local class_location = nil
   for idx, location in pairs(resp.result) do
-    utils.notify("Debug", { msg = vim.inspect(location), level = "INFO" })
-    if location.containerName .. "\\" .. location.name == action[1] then
+    if location.location and
+	location.containerName .. "\\" .. location.name == action[1] and
+	vim.lsp.util._get_symbol_kind_name(location.kind) == "Class" then
       class_location = location
       break
     end


### PR DESCRIPTION
I found this issue in my setup, i do not think it is my local issue, please check it out.

This fixes `:Laravel routes` command navigation to file after selection

It may make sense to remove whole `locations = symbols_to_items` part, but i guess it still adds some additional checks.

The only issue I could see, is that with this approach, we do not check if found symbol is Class, but i think if we compare fully qualified class name that should be enough?

I do not have any experience developing in Lua or using LSP.