### PR TITLE
Refresh environments on initialize

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,28 +129,28 @@ Default configuration
 ## Environments
 There are many ways to run your laravel application, could be natively in you computer, using docker-compose, using sail, or others.
 Even using docker-compose you could have differences from project to project.
-In order to support this I have set a new configuration `environment`. Here you can set 2 properties.
-`resolver` this takes cares on determine which environment to use.
-This resolver will return the environment to use. This resolver first will look for an environment variable `NVIM_LARAVEL_ENV` with this will look with a configured environment with the same name.
-If is not set will be ignore, if it is set but could not find will throw an error.
-Next is the auto auto-discovery this will look for docker-compose is present and sail file in the vendor directory. If they are will use sail.
-If only docker-compose.yml file is present will use docker-compose environment
-If they are not will check if the php is executable will use local environment.
+In order to support this there is an `environment` configuration. Here you can set 2 properties.
+`resolver` takes care of determining which environment to use.
+The resolver will return the environment to use. The resolver will first look for an environment variable `NVIM_LARAVEL_ENV` which should correspond to configured environment name.
+If is not set it will be ignored, if it is set but could not be found an error will be thrown.
+Next is the auto auto-discovery this will look for docker-compose file and Sail file in the vendor directory. If they are present Sail will be used.
+If only docker-compose.yml file is present docker-compose environment will be used.
+If both checks fail will check if the php is executable and then local environment will be used.
 The third part is try to use the provided default.
-You can configure the resolver my passing parameters
+You can configure the resolver by passing parameters
 ```lua
 ---@param env_check boolean
 ---@param auto_discovery boolean
 ---@param default string|nil
 return function(env_check, auto_discovery, default)
 ```
-so to the resolver you can set to ignore the environment variable, ignore the auto_direcovery and just use the default
+Resolver can be configured to ignore environment variable, ignore auto-discovery and just use the default
 ```lua
     resolver = require "laravel.environment.resolver"(false, false, "sail"),
 ```
 
-The environment needs to return a list of executables in format of a table. This will be use when running the `run` method on the application `require('laravel.application').run('<command>', {"args"}, {options})`
-Let say you want to modify the sail command to be use you can do it by calling the setup method on the environment sail with options cmd
+The environment needs to return a function that returns a list of executables in format of a table. This will be used when running the `run` method on the application `require('laravel.application').run('<command>', {"args"}, {options})`
+Let say you want to modify the Sail command, you can do it by calling the setup method on the environment Sail with options cmd
 ```lua
       ["sail"] = require("laravel.environment.sail").setup({cmd = {"my-sail-binary"}}),
 ```

--- a/lua/laravel/application/init.lua
+++ b/lua/laravel/application/init.lua
@@ -16,15 +16,16 @@ local initialize = function(options)
     return
   end
 
-  local env = environment.initialize(options.environment.environments, options.environment.resolver)
+  local resolvedEnv = environment.initialize(options.environment.environments, options.environment.resolver)
   -- fill with the environment
-  if not env then
+  if not resolvedEnv then
     utils.notify("App", { msg = "Could not initialize environment", level = "ERROR" })
     return
   end
 
   app = {
-    environment = env(),
+    envSetup = resolvedEnv,
+    environment = resolvedEnv(),
     options = options,
   }
 end
@@ -63,6 +64,7 @@ local build_command = function(command, args)
 end
 
 local warmup = function()
+  app.environment = app.envSetup()
   require("laravel.commands").load()
   require("laravel.routes").load()
 end

--- a/lua/laravel/application/init.lua
+++ b/lua/laravel/application/init.lua
@@ -24,7 +24,7 @@ local initialize = function(options)
   end
 
   app = {
-    environment = env,
+    environment = env(),
     options = options,
   }
 end

--- a/lua/laravel/environment/docker_compose.lua
+++ b/lua/laravel/environment/docker_compose.lua
@@ -3,30 +3,32 @@ local utils = require "laravel.utils"
 local M = {}
 
 ---@param opts table|nil
----@return table
+---@return function
 M.setup = function(opts)
-  opts = opts or {}
+  return function()
+    opts = opts or {}
 
-  local container = utils.get_env "APP_SERVICE" or opts.container_name or "app"
+    local container = utils.get_env "APP_SERVICE" or opts.container_name or "app"
 
-  local cmd = opts.cmd or { "docker", "compose", "exec", "-it", container }
+    local cmd = opts.cmd or { "docker", "compose", "exec", "-it", container }
 
-  local function get_cmd(args)
-    return vim.fn.extend(cmd, args)
+    local function get_cmd(args)
+      return vim.fn.extend(cmd, args)
+    end
+
+    local executables = {
+      artisan = opts.artisan or get_cmd { "php", "artisan" },
+      composer = opts.composer or get_cmd { "composer" },
+      npm = opts.npm or get_cmd { "npm" },
+      yarn = opts.yarn or get_cmd { "yarn" },
+      php = opts.php or get_cmd { "php" },
+      compose = opts.compose or { "docker", "compose" },
+    }
+
+    return {
+      executables = vim.tbl_deep_extend("force", executables, opts.executables or {}),
+    }
   end
-
-  local executables = {
-    artisan = opts.artisan or get_cmd { "php", "artisan" },
-    composer = opts.composer or get_cmd { "composer" },
-    npm = opts.npm or get_cmd { "npm" },
-    yarn = opts.yarn or get_cmd { "yarn" },
-    php = opts.php or get_cmd { "php" },
-    compose = opts.compose or { "docker", "compose" },
-  }
-
-  return {
-    executables = vim.tbl_deep_extend("force", executables, opts.executables or {}),
-  }
 end
 
 return M

--- a/lua/laravel/environment/native.lua
+++ b/lua/laravel/environment/native.lua
@@ -1,21 +1,23 @@
 local M = {}
 
 ---@param opts table|nil
----@return table
+---@return function
 M.setup = function(opts)
-  opts = opts or {}
+  return function()
+    opts = opts or {}
 
-  local executables = {
-    artisan = opts.artisan or { "php", "artisan" },
-    composer = opts.composer or { "composer" },
-    npm = opts.npm or { "npm" },
-    yarn = opts.yarn or { "yarn" },
-    php = opts.php or { "php" },
-  }
+    local executables = {
+      artisan = opts.artisan or { "php", "artisan" },
+      composer = opts.composer or { "composer" },
+      npm = opts.npm or { "npm" },
+      yarn = opts.yarn or { "yarn" },
+      php = opts.php or { "php" },
+    }
 
-  return {
-    executables = vim.tbl_deep_extend("force", executables, opts.executables or {}),
-  }
+    return {
+      executables = vim.tbl_deep_extend("force", executables, opts.executables or {}),
+    }
+  end
 end
 
 return M

--- a/lua/laravel/environment/sail.lua
+++ b/lua/laravel/environment/sail.lua
@@ -1,28 +1,30 @@
 local M = {}
 
 ---@param opts table|nil
----@return table
+---@return function
 M.setup = function(opts)
-  opts = opts or {}
+  return function()
+    opts = opts or {}
 
-  local cmd = opts.cmd or { "vendor/bin/sail" }
+    local cmd = opts.cmd or { "vendor/bin/sail" }
 
-  local function get_cmd(args)
-    return vim.fn.extend(cmd, args)
+    local function get_cmd(args)
+      return vim.fn.extend(cmd, args)
+    end
+
+    local executables = {
+      artisan = opts.artisan or get_cmd { "artisan" },
+      composer = opts.composer or get_cmd { "composer" },
+      npm = opts.npm or get_cmd { "npm" },
+      yarn = opts.yarn or get_cmd { "yarn" },
+      sail = opts.sail or cmd,
+      php = opts.php or get_cmd { "php" },
+    }
+
+    return {
+      executables = vim.tbl_deep_extend("force", executables, opts.executables or {}),
+    }
   end
-
-  local executables = {
-    artisan = opts.artisan or get_cmd { "artisan" },
-    composer = opts.composer or get_cmd { "composer" },
-    npm = opts.npm or get_cmd { "npm" },
-    yarn = opts.yarn or get_cmd { "yarn" },
-    sail = opts.sail or cmd,
-    php = opts.php or get_cmd { "php" },
-  }
-
-  return {
-    executables = vim.tbl_deep_extend("force", executables, opts.executables or {}),
-  }
 end
 
 return M

--- a/lua/laravel/init.lua
+++ b/lua/laravel/init.lua
@@ -17,13 +17,15 @@ function M.setup(opts)
 
   local options = vim.tbl_deep_extend("force", defaults, opts or {})
 
-  application.initialize(options)
+  if not application.ready() then
+    application.initialize(options)
+  else
+    application.warmup()
+  end
 
   if not application.ready() then
     return
   end
-
-  application.warmup()
 
   -- TODO: remove once 0.9 was general available
   if vim.fn.has "nvim-0.9.0" ~= 1 then


### PR DESCRIPTION
@adalessa It worked for me, but when i reopened the editor - it stopped.

I once again did some debugging and found out, that it only works for me if I start editor in the project directory
```
nvim ~/projects/example
```

If i start the editor in a random dir (as I normally do tbh), docker-compose container_name is already set to ''.

The  reason is simple, we are not initializing environments again on DirChanged autocommand and the utils.get_env "APP_SERVICE"  is not resetting for new dir. 