### PR TITLE
fix: for terminal and buffer \ are not being properly escaped. Could …

### DIFF
--- a/lua/laravel/_config.lua
+++ b/lua/laravel/_config.lua
@@ -23,6 +23,7 @@ local config = {
   route_info = true,
   default_runner = "terminal",
   commands_runner = {
+    ["model:show"] = "buffer",
     ["dump-server"] = "persist",
     ["queue:listen"] = "persist",
     ["serve"] = "persist",

--- a/lua/laravel/runners/buffer.lua
+++ b/lua/laravel/runners/buffer.lua
@@ -33,6 +33,11 @@ return function(cmd, opts)
     vim.fn.chansend(channel_id, data)
   end
 
+  -- this is to escape namespaces
+  for index, value in ipairs(cmd) do
+    cmd[index] = value:gsub("\\", "\\\\")
+  end
+
   local job_id = vim.fn.jobstart(vim.fn.join(cmd, " "), {
     stdeout_buffered = true,
     on_stdout = handle_output,


### PR DESCRIPTION
…fix for terminal but this is a fix for buffer