### PR TITLE
NullLS - call done() at the end of completion source (fix for Mini.Completion)

### DIFF
--- a/lua/laravel/null_ls/completion/init.lua
+++ b/lua/laravel/null_ls/completion/init.lua
@@ -137,7 +137,7 @@ function M.setup()
           end
         end
         --- END Completion routes
-        done({ { items = {}, isIncomplete = false } })
+        done { { items = {}, isIncomplete = false } }
       end,
       async = true,
     },

--- a/lua/laravel/null_ls/completion/init.lua
+++ b/lua/laravel/null_ls/completion/init.lua
@@ -137,6 +137,7 @@ function M.setup()
           end
         end
         --- END Completion routes
+        done({ { items = {}, isIncomplete = false } })
       end,
       async = true,
     },


### PR DESCRIPTION
Omnifunc refuses to open when using mini completion without properly calling done(). This PR fixes the issue