### PR TITLE
Make use of Nvim's new vim.health functions if available

### DIFF
--- a/lua/laravel/health.lua
+++ b/lua/laravel/health.lua
@@ -15,10 +15,7 @@ M.check = function()
   if vim.fn.executable "rg" == 1 then
     report_ok "rg installed"
   else
-    report_warn(
-      "ripgrep is missing, is required for finding view usage",
-      { "Installed from your package manager" }
-    )
+    report_warn("ripgrep is missing, is required for finding view usage", { "Installed from your package manager" })
   end
 
   report_start "Plugin Dependencies"
@@ -96,10 +93,7 @@ M.check = function()
     if api.is_composer_package_install(dependency.name) then
       report_ok(string.format("Composer dependency `%s` is installed", dependency.name))
     else
-      report_warn(
-        string.format("Composer dependency `%s` is not installed", dependency.name),
-        { dependency.messages }
-      )
+      report_warn(string.format("Composer dependency `%s` is not installed", dependency.name), { dependency.messages })
     end
   end
 end

--- a/lua/laravel/health.lua
+++ b/lua/laravel/health.lua
@@ -2,34 +2,40 @@ local environment = require "laravel.environment"
 local api = require "laravel.api"
 local M = {}
 
-M.check = function()
-  vim.health.report_start "Laravel"
+local report_start = vim.health.start or vim.health.report_start
+local report_ok = vim.health.ok or vim.health.report_ok
+local report_info = vim.health.info or vim.health.report_info
+local report_warn = vim.health.warn or vim.health.report_warn
+local report_error = vim.health.error or vim.health.report_error
 
-  vim.health.report_start "External Dependencies"
+M.check = function()
+  report_start "Laravel"
+
+  report_start "External Dependencies"
   if vim.fn.executable "rg" == 1 then
-    vim.health.report_ok "rg installed"
+    report_ok "rg installed"
   else
-    vim.health.report_warn(
+    report_warn(
       "ripgrep is missing, is required for finding view usage",
       { "Installed from your package manager" }
     )
   end
 
-  vim.health.report_start "Plugin Dependencies"
+  report_start "Plugin Dependencies"
   local ok_null_ls, _ = pcall(require, "null-ls")
   if ok_null_ls then
-    vim.health.report_ok "Null LS is installed"
+    report_ok "Null LS is installed"
   else
-    vim.health.report_warn(
+    report_warn(
       "Null LS is not installed, this is use to add completion, diagnostic and Code actions",
       { "Install it from `https://github.com/nvimtools/none-ls.nvim`" }
     )
   end
   local ok_luannip, _ = pcall(require, "luasnip")
   if ok_luannip then
-    vim.health.report_ok "luasnip is installed"
+    report_ok "luasnip is installed"
   else
-    vim.health.report_warn(
+    report_warn(
       "Luasnip is not installed, this is use to snippets related to larevel",
       { "Install it from `https://github.com/L3MON4D3/LuaSnip`" }
     )
@@ -37,9 +43,9 @@ M.check = function()
 
   local ok_nui, _ = pcall(require, "nui.popup")
   if ok_nui then
-    vim.health.report_ok "Nui is installed"
+    report_ok "Nui is installed"
   else
-    vim.health.report_warn(
+    report_warn(
       "Nui is not installed, this is use to create the UI for the command",
       { "Install it from `https://github.com/MunifTanjim/nui.nvim`" }
     )
@@ -47,36 +53,36 @@ M.check = function()
 
   local ok_telescope, _ = pcall(require, "telescope")
   if ok_telescope then
-    vim.health.report_ok "Telescope is installed"
+    report_ok "Telescope is installed"
   else
-    vim.health.report_warn(
+    report_warn(
       "Telescope is not installed, A lot of functions uses telescope for the pickers",
       { "Install it from `https://github.com/nvim-telescope/telescope.nvim`" }
     )
   end
 
-  vim.health.report_start "Environment"
+  report_start "Environment"
 
   if not environment.environment then
-    vim.health.report_error(
+    report_error(
       "Environment not configure for this directory, no more checks",
       { "Check project is laravel, current directory `:pwd` is the root of laravel project" }
     )
     return
   end
 
-  vim.health.report_ok "Environment setup successful"
+  report_ok "Environment setup successful"
 
-  vim.health.report_info("Name: " .. environment.environment.name)
-  vim.health.report_info "Condition: "
-  vim.health.report_info(vim.inspect(environment.environment.condition))
-  vim.health.report_info "Commands: "
-  vim.health.report_info(vim.inspect(environment.environment.commands))
+  report_info("Name: " .. environment.environment.name)
+  report_info "Condition: "
+  report_info(vim.inspect(environment.environment.condition))
+  report_info "Commands: "
+  report_info(vim.inspect(environment.environment.commands))
 
-  vim.health.report_start "Composer Dependencies"
+  report_start "Composer Dependencies"
 
   if not environment.get_executable "composer" then
-    vim.health.report_error "Composer executable not found can't check dependencies"
+    report_error "Composer executable not found can't check dependencies"
   end
 
   local composer_dependencies = {
@@ -88,9 +94,9 @@ M.check = function()
 
   for _, dependency in pairs(composer_dependencies) do
     if api.is_composer_package_install(dependency.name) then
-      vim.health.report_ok(string.format("Composer dependency `%s` is installed", dependency.name))
+      report_ok(string.format("Composer dependency `%s` is installed", dependency.name))
     else
-      vim.health.report_warn(
+      report_warn(
         string.format("Composer dependency `%s` is not installed", dependency.name),
         { dependency.messages }
       )


### PR DESCRIPTION
The `vim.health.report_` functions have been deprecated as of Nvim 0.10 and will be removed in 0.11.

This PR adds aliases to each of the health functions that are used to ensure the new functions are used when possible and maintaining backwards compatibility for 0.9 and before.

Tested locally on my Neovim 0.10 instance on MacOS:

```
==============================================================================
laravel: require("laravel.health").check()

Laravel ~

External Dependencies ~
- OK rg installed

Plugin Dependencies ~
- OK Null LS is installed
- OK luasnip is installed
- OK Nui is installed
- OK Telescope is installed

Environment ~
- OK Environment setup successful
- Name: local
- Condition: 
- {
    executable = { "php" }
  }
- Commands: 
- {}

Composer Dependencies ~
- OK Composer dependency `laravel/tinker` is installed
```

Using v2.1.1:

```
laravel: require("laravel.health").check()

- WARNING vim.health.report_start() is deprecated, use vim.health.start() instead. :help |deprecated|
  Feature will be removed in Nvim 0.11

Laravel ~

External Dependencies ~
- WARNING vim.health.report_ok() is deprecated, use vim.health.ok() instead. :help |deprecated|
  Feature will be removed in Nvim 0.11
- OK rg installed

Plugin Dependencies ~
- OK Null LS is installed
- OK luasnip is installed
- OK Nui is installed
- OK Telescope is installed

Environment ~
- OK Environment setup successful
- WARNING vim.health.report_info() is deprecated, use vim.health.info() instead. :help |deprecated|
  Feature will be removed in Nvim 0.11
- Name: local
- Condition: 
- {
    executable = { "php" }
  }
- Commands: 
- {}

Composer Dependencies ~
- OK Composer dependency `laravel/tinker` is installed
```