### PR TITLE
feat: Optionally show/disable the info text

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,21 @@ return {
     { "<leader>lm", ":Laravel related<cr>" },
   },
   event = { "VeryLazy" },
+  opts = {
+      features = {
+        null_ls = {
+          enable = true,
+        },
+        route_info = {
+          enable = true,         --- to enable the laravel.nvim virtual text
+          position = 'right',    --- where to show the info (available options 'right', 'top')
+          middlewares = true,    --- wheather to show the middlewares section in the info
+          method = true,         --- wheather to show the method section in the info
+          uri = true             --- wheather to show the uri section in the info
+        },
+      },
+    },
+  }
   config = true,
 }
 ```

--- a/lua/laravel/config/default.lua
+++ b/lua/laravel/config/default.lua
@@ -3,6 +3,9 @@
 
 ---@class RouteInfoFeature
 ---@field enable boolean
+---@field middlewares boolean
+---@field method boolean
+---@field uri boolean
 ---@field position string
 
 ---@class LaravelFeatures
@@ -27,6 +30,9 @@ return {
     },
     route_info = {
       enable = true,
+      middlewares = true,
+      method = true,
+      uri = true,
       position = "right",
     },
   },

--- a/lua/laravel/route_info/init.lua
+++ b/lua/laravel/route_info/init.lua
@@ -15,34 +15,57 @@ end
 
 local function generate_virtual_text_options(route, indent)
   if options.position == "right" then
+    local virt_text = {
+      { "[", "comment" },
+    }
+
+    if options.method then
+      table.insert(virt_text, { " Method: ", "comment" })
+      table.insert(virt_text, { route.methods[1], "@enum" })
+    end
+
+    if options.uri then
+      table.insert(virt_text, { " Uri: ", "comment" })
+      table.insert(virt_text, { route.uri, "@enum" })
+    end
+
+    if options.middlewares then
+      table.insert(virt_text, { " Middleware: ", "comment" })
+      table.insert(virt_text, { vim.fn.join(route.middlewares or { "None" }, ","), "@enum" })
+    end
+
+    table.insert(virt_text, { "]", "comment" })
+
     return {
-      virt_text = {
-        { "[", "comment" },
-        { "Method: ", "comment" },
-        { vim.fn.join(route.methods, "|"), "@enum" },
-        { " Uri: ", "comment" },
-        { route.uri, "@enum" },
-        { " Middleware: ", "comment" },
-        { vim.fn.join(route.middlewares or { "None" }, ","), "@enum" },
-        { "]", "comment" },
-      },
+      virt_text = virt_text,
     }
   end
   if options.position == "top" then
+
     local middleware_lines = {}
-    for _, mw in ipairs(route.middlewares or { "None" }) do
-      table.insert(middleware_lines, { {indent .. "  " .. mw, "@enum"} })
+    if options.middlewares then
+      for _, mw in ipairs(route.middlewares or { "None" }) do
+        table.insert(middleware_lines, { {indent .. "  " .. mw, "@enum"} })
+      end
     end
 
     local virt_lines = {
-      { { indent .. "[", "comment" } },
-      { { indent .. " Method: ", "comment" }, { vim.fn.join(route.methods, "|"), "@enum" } },
-      { { indent .. " Uri: ", "comment" }, { route.uri, "@enum" } },
-      { { indent .. " Middleware: ", "comment" } },
+      { { indent .. "[", "comment" } }
     }
 
-    for _, line in ipairs(middleware_lines) do
-      table.insert(virt_lines, line)
+    if options.method then
+      table.insert(virt_lines, { { indent .. " Method: ", "comment" }, { vim.fn.join(route.methods, "|"), "@enum" } })
+    end
+
+    if options.uri then
+      table.insert(virt_lines, { { indent .. " Uri: ", "comment" }, { route.uri, "@enum" } })
+    end
+
+    if options.middlewares then
+      table.insert(virt_lines,  { { indent .. " Middleware: ", "comment" } })
+      for _, line in ipairs(middleware_lines) do
+        table.insert(virt_lines, line)
+      end
     end
 
     table.insert(virt_lines, { { indent .. "]", "comment" } })


### PR DESCRIPTION
This PR introduces a feature to display info text objects conditionally. 

**Defaults are not changed**

**Changes Made**
Added functionality to conditionally render info text objects.

**Configuration Options**: Introduced new configuration settings to disable text objects.
```
  opts = {
      features = {
        null_ls = {
          enable = true,
        },
        route_info = {
          enable = true,         --- to enable the laravel.nvim virtual text
          position = 'right',    --- where to show the info (available options 'right', 'top')
          middlewares = true,    --- wheather to show the middlewares section in the info
          method = true,         --- wheather to show the method section in the info
          uri = true             --- wheather to show the uri section in the info
        },
      },
    },
  }
```

**Documentation**: Updated the plugin's documentation to reflect the new feature and provide examples for usage.
