### PR TITLE
fix: replace the 'vim.lsp.get_active_clients' deprecated function with it's replacement

### DIFF
--- a/lua/laravel/_lsp/init.lua
+++ b/lua/laravel/_lsp/init.lua
@@ -10,7 +10,7 @@ local servers = {
 ---@param server_name string
 ---@return table|nil, boolean
 local get_client = function(server_name)
-  local clients = vim.lsp.get_active_clients { name = server_name }
+  local clients = vim.lsp.get_clients { name = server_name }
   local client = clients[1] or nil
   local new_instance = false
 


### PR DESCRIPTION
'vim.lsp.get_active_clients'  is depricated so updating it with its replacement ' 'vim.lsp.get_clients' 