### PR TITLE
Fix syntax error in LazyVim installation details

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,20 +33,19 @@ return {
   },
   event = { "VeryLazy" },
   opts = {
-      features = {
-        null_ls = {
-          enable = true,
-        },
-        route_info = {
-          enable = true,         --- to enable the laravel.nvim virtual text
-          position = 'right',    --- where to show the info (available options 'right', 'top')
-          middlewares = true,    --- wheather to show the middlewares section in the info
-          method = true,         --- wheather to show the method section in the info
-          uri = true             --- wheather to show the uri section in the info
-        },
+    features = {
+      null_ls = {
+        enable = true,
+      },
+      route_info = {
+        enable = true,         --- to enable the laravel.nvim virtual text
+        position = 'right',    --- where to show the info (available options 'right', 'top')
+        middlewares = true,    --- wheather to show the middlewares section in the info
+        method = true,         --- wheather to show the method section in the info
+        uri = true             --- wheather to show the uri section in the info
       },
     },
-  }
+  },
   config = true,
 }
 ```


### PR DESCRIPTION
Small fix for a syntax error in the LazyVim installation.

## Currently:
![CleanShot 2024-09-01 at 12 02 08@2x](https://github.com/user-attachments/assets/2fa101c3-c40f-4670-9af9-8231465dd15c)

## After change:
![CleanShot 2024-09-01 at 12 03 20@2x](https://github.com/user-attachments/assets/ed4f42b3-cf12-49ea-a8fa-57cea4c8a535)