### PR TITLE
fg keymaps renamed to lg so it does not interfere with vim f key

### DIFF
--- a/ftplugin/blade.lua
+++ b/ftplugin/blade.lua
@@ -1,6 +1,6 @@
 --- Here set things for blade
-vim.keymap.set({ "n" }, "fg", function()
+vim.keymap.set({ "n" }, "lg", function()
   vim.print("Here needs to find the view if in extends or how")
 
-  vim.cmd("normal! fg")
+  vim.cmd("normal! lg")
 end, { buffer = 0 })

--- a/ftplugin/php.lua
+++ b/ftplugin/php.lua
@@ -1,7 +1,7 @@
 --- Here set things for php buffers
 
-vim.keymap.set({ "n" }, "fg", function()
-  vim.print("checks if is in a view if not trigger the old fg")
+vim.keymap.set({ "n" }, "lg", function()
+  vim.print("checks if is in a view if not trigger the old lg")
 
-  vim.cmd("normal! fg")
+  vim.cmd("normal! lg")
 end, { buffer = 0 })


### PR DESCRIPTION
fg keymaps renamed to lg so it does not interfere with vim f key and/or plugins such as eyeliner.lua

It makes more sense to keep keymaps under [l]aravel [*] for the plugin if it has to set them.

f is a vim command for find, and having a keybinding fg delays the trigger of f, but also **makes it impossible to use fg to find the next occurence of the letter g.**