### PR TITLE
Removed redundant fg keymaps for blade/php filetypes (improves compatibility with plugins such as eyeliner that hijack the f key)

### DIFF
--- a/ftplugin/blade.lua
+++ b/ftplugin/blade.lua
@@ -1,6 +1,7 @@
 --- Here set things for blade
-vim.keymap.set({ "n" }, "lg", function()
-  vim.print("Here needs to find the view if in extends or how")
 
-  vim.cmd("normal! lg")
-end, { buffer = 0 })
+-- vim.keymap.set({ "n" }, "fg", function()
+--   vim.print("Here needs to find the view if in extends or how")
+--
+--   vim.cmd("normal! fg")
+-- end, { buffer = 0 })

--- a/ftplugin/blade.lua
+++ b/ftplugin/blade.lua
@@ -1,6 +1,6 @@
 --- Here set things for blade
-vim.keymap.set({ "n" }, "fg", function()
+vim.keymap.set({ "n" }, "lg", function()
   vim.print("Here needs to find the view if in extends or how")
 
-  vim.cmd("normal! fg")
+  vim.cmd("normal! lg")
 end, { buffer = 0 })

--- a/ftplugin/php.lua
+++ b/ftplugin/php.lua
@@ -1,7 +1,7 @@
 --- Here set things for php buffers
 
-vim.keymap.set({ "n" }, "lg", function()
-  vim.print("checks if is in a view if not trigger the old lg")
-
-  vim.cmd("normal! lg")
-end, { buffer = 0 })
+-- vim.keymap.set({ "n" }, "fg", function()
+--   vim.print("checks if is in a view if not trigger the old fg")
+--
+--   vim.cmd("normal! fg")
+-- end, { buffer = 0 })

--- a/ftplugin/php.lua
+++ b/ftplugin/php.lua
@@ -1,7 +1,7 @@
 --- Here set things for php buffers
 
-vim.keymap.set({ "n" }, "fg", function()
-  vim.print("checks if is in a view if not trigger the old fg")
+vim.keymap.set({ "n" }, "lg", function()
+  vim.print("checks if is in a view if not trigger the old lg")
 
-  vim.cmd("normal! fg")
+  vim.cmd("normal! lg")
 end, { buffer = 0 })


### PR DESCRIPTION
There isn't any benefit to having the code in there as it doesn't do anything, and commenting it out stops the delay when pressing the f key when used with plugins such as eyeliner