### PR TITLE
removed redundant ftplugin keymaps

### DIFF
--- a/ftplugin/blade.lua
+++ b/ftplugin/blade.lua
@@ -1,6 +1,7 @@
 --- Here set things for blade
-vim.keymap.set({ "n" }, "fg", function()
-  vim.print("Here needs to find the view if in extends or how")
 
-  vim.cmd("normal! fg")
-end, { buffer = 0 })
+-- vim.keymap.set({ "n" }, "fg", function()
+--   vim.print("Here needs to find the view if in extends or how")
+--
+--   vim.cmd("normal! fg")
+-- end, { buffer = 0 })

--- a/ftplugin/php.lua
+++ b/ftplugin/php.lua
@@ -1,7 +1,7 @@
 --- Here set things for php buffers
 
-vim.keymap.set({ "n" }, "fg", function()
-  vim.print("checks if is in a view if not trigger the old fg")
-
-  vim.cmd("normal! fg")
-end, { buffer = 0 })
+-- vim.keymap.set({ "n" }, "fg", function()
+--   vim.print("checks if is in a view if not trigger the old fg")
+--
+--   vim.cmd("normal! fg")
+-- end, { buffer = 0 })


### PR DESCRIPTION
Removed the redundant keymaps as it interferes with plugins such as eyeliner.lua that hijack the f key.

The maps don't do anything so they can safely be commented out