### PR TITLE
removed redundant key bindings

### DIFF
--- a/ftplugin/blade.lua
+++ b/ftplugin/blade.lua
@@ -1,6 +1,7 @@
 --- Here set things for blade
-vim.keymap.set({ "n" }, "fg", function()
-  vim.print("Here needs to find the view if in extends or how")
 
-  vim.cmd("normal! fg")
-end, { buffer = 0 })
+-- vim.keymap.set({ "n" }, "fg", function()
+--   vim.print("Here needs to find the view if in extends or how")
+--
+--   vim.cmd("normal! fg")
+-- end, { buffer = 0 })

--- a/ftplugin/php.lua
+++ b/ftplugin/php.lua
@@ -1,7 +1,7 @@
 --- Here set things for php buffers
 
-vim.keymap.set({ "n" }, "fg", function()
-  vim.print("checks if is in a view if not trigger the old fg")
-
-  vim.cmd("normal! fg")
-end, { buffer = 0 })
+-- vim.keymap.set({ "n" }, "fg", function()
+--   vim.print("checks if is in a view if not trigger the old fg")
+--
+--   vim.cmd("normal! fg")
+-- end, { buffer = 0 })


### PR DESCRIPTION
I've removed the redundant key bindings in the ftplugin directory as they interfere with plugins which hijack the f key such as eyeliner.lua

(sorry for all the closed pull requests, my machine was auto closing them)