### PR TITLE
new(route picker): add route name to telescope's route picker fuzzy searched value

### DIFF
--- a/lua/laravel/pickers/telescope/make_entry.lua
+++ b/lua/laravel/pickers/telescope/make_entry.lua
@@ -58,7 +58,7 @@ function M.gen_from_laravel_routes(opts)
   return function(route)
     return M.set_default_entry_mt({
       value = route,
-      ordinal = route.uri,
+      ordinal = vim.fn.join({ route.uri, route.name or "" }, " "),
       display = make_display,
       route_method = vim.fn.join(route.methods, "|"),
     }, opts)


### PR DESCRIPTION
Include the route name in the value being searched by telescope for the `Laravel routes` command