### PR TITLE
Add Herd support and fix typo

### DIFF
--- a/lua/laravel/options/environments.lua
+++ b/lua/laravel/options/environments.lua
@@ -51,6 +51,19 @@ return {
       },
     },
     {
+      name = "herd",
+      condition = {
+        executable = { "herd" },
+      },
+      commands = {
+        herd = { "herd" },
+        {
+          commands = { "php", "composer" },
+          prefix = { "herd" },
+        },
+      },
+    },
+    {
       name = "local",
       condition = {
         executable = { "php" },

--- a/lua/laravel/options/environments.lua
+++ b/lua/laravel/options/environments.lua
@@ -9,12 +9,12 @@
 
 ---@class LaravelOptionsEnvironments
 ---@field env_variable string
----@field auto_dicover boolean
+---@field auto_discover boolean
 ---@field default string
 ---@field definitions LaravelEnvironmentConfig[]
 return {
   env_variable = "NVIM_LARAVEL_ENV",
-  auto_dicover = true,
+  auto_discover = true,
   default = "local",
   definitions = {
     {

--- a/lua/laravel/services/environment.lua
+++ b/lua/laravel/services/environment.lua
@@ -50,7 +50,7 @@ function environment:boot()
     end
   end
 
-  if opts.auto_dicover then
+  if opts.auto_discover then
     for _, opt in ipairs(opts.definitions) do
       local env = Environment:new(opt)
       if env:check() then


### PR DESCRIPTION
Added herd support becasue it allows for different php versions and in order to run artisan commands correctly they must be prefixed with `herd ..` e.g. `herd php artisan route:list` or `herd composer install`.  Also fixed a typo in the environments file, If it was a typo :).