### PR TITLE
Graceful handling when database or table aren't provided

### DIFF
--- a/lua/laravel/services/model_info_view.lua
+++ b/lua/laravel/services/model_info_view.lua
@@ -4,10 +4,17 @@ local model_info_view = {}
 function model_info_view:get(model)
   local virt_lines = {
     { { "[", "comment" } },
-    { { " Database: ", "comment" },  { model.database, "@enum" } },
-    { { " Table: ", "comment" },     { model.table, "@enum" } },
-    { { " Attributes: ", "comment" } },
   }
+
+  if model.database then
+    table.insert(virt_lines, { { " Database: ", "comment" }, { model.database, "@enum" } })
+  end
+
+  if model.table then
+    table.insert(virt_lines, { { " Table: ", "comment" }, { model.table, "@enum" } })
+  end
+
+  table.insert(virt_lines, { { " Attributes: ", "comment" } })
 
   for _, attribute in ipairs(model.attributes) do
     table.insert(virt_lines, {


### PR DESCRIPTION
## Changes
When the `model.database` or `model.table` are empty, filter them from the virtual text appended.

### Issue encountered
When using [Sushi](https://github.com/calebporzio/sushi) the `php artisan show:model` cmd it return an empty `database` in the output. Thus causing the following issue to pop when accessing the model.
```
   Error  18:57:54 msg_show.lua_error Error executing vim.schedule lua callback: UnhandledPromiseRejection with the reason:
...plugins/laravel.nvim/lua/laravel/services/model_info.lua:25: Invalid chunk: expected Array with 1 or 2 Strings
stack traceback:
	[C]: in function 'nvim_buf_set_extmark'
	...plugins/laravel.nvim/lua/laravel/services/model_info.lua:25: in function <...plugins/laravel.nvim/lua/laravel/services/model_info.lua:23>
``` 

