### PR TITLE
Fix check for jq and add a healthcheck for it

### DIFF
--- a/lua/laravel/core/config.lua
+++ b/lua/laravel/core/config.lua
@@ -65,8 +65,8 @@ function config:save()
   end
 
   local json = vim.json.encode(self.data)
-  if vim.fn.executable("jq") then
-    local out = vim.system({"jq"}, {stdin = json}):wait()
+  if vim.fn.executable("jq") == 1 then
+    local out = vim.system({ "jq" }, { stdin = json }):wait()
     json = out.stdout
   end
   file:write(json)

--- a/lua/laravel/health.lua
+++ b/lua/laravel/health.lua
@@ -16,6 +16,15 @@ M.check = function()
     report_error("ripgrep is missing, is required for finding view usage", { "Installed from your package manager" })
   end
 
+  if vim.fn.executable("jq") == 1 then
+    report_ok("jq installed")
+  else
+    report_warn(
+      "jq is missing, although it is not required, is a nice tool to have",
+      { "Install it from your package manager or from `https://jqlang.org/download/`" }
+    )
+  end
+
   report_start("Plugin Dependencies")
 
   local ok_nui, _ = pcall(require, "nui.popup")


### PR DESCRIPTION
This fixes an error when opening for the first time a project and the user does not have `jq`.


https://github.com/user-attachments/assets/565c3be1-5cbf-46bb-8e5a-839ea2ad34ec

