### PR TITLE
fix: don't crash when opening Tinker from a buffer with no name (new buffer, `[No Name]`)

### DIFF
--- a/lua/laravel/extensions/tinker/lib.lua
+++ b/lua/laravel/extensions/tinker/lib.lua
@@ -63,13 +63,15 @@ function tinker:open(filename)
   end
 
   local bufnr = vim.uri_to_bufnr(vim.uri_from_fname(file))
-  vim.cmd("write")
+  pcall(function()
+    vim.cmd("write")
+  end)
   vim.fn.bufload(bufnr)
 
   self.ui:open(bufnr, filename, function()
     self.data.file = {}
 
-    if Laravel.app('laravel.extensions.dump_server.lib'):isRunning() then
+    if Laravel.app("laravel.extensions.dump_server.lib"):isRunning() then
       notify.warn("Dump server is running, please stop it before using tinker")
 
       return


### PR DESCRIPTION
Currently, when attempting to open the Tinker tool while on a new buffer (without name), the command crashes because of failing to `write` the current buffer.

Trace: 
```
E5108: Error executing lua: ...s/javo/.local/share/nvim/lazy/nvim-nio/lua/nio/tasks.lua:100: Async task failed without callback: The coroutine failed with this message: 
vim/_editor.lua:0: nvim_exec2(), line 1: Vim(write):E32: No file name
stack traceback:
	[C]: in function 'nvim_exec2'
	vim/_editor.lua: in function 'cmd'
	...ugins/laravel.nvim/lua/laravel/extensions/tinker/lib.lua:67: in function 'open'
	.../laravel.nvim/lua/laravel/extensions/tinker/commands.lua:10: in function 'handle'
	...laravel.nvim/lua/laravel/providers/commands_provider.lua:40: in function 'func'
	...s/javo/.local/share/nvim/lazy/nvim-nio/lua/nio/tasks.lua:169: in function <...s/javo/.local/share/nvim/lazy/nvim-nio/lua/nio/tasks.lua:168>
stack traceback:
	[C]: in function 'error'
	...s/javo/.local/share/nvim/lazy/nvim-nio/lua/nio/tasks.lua:100: in function 'close_task'
	...s/javo/.local/share/nvim/lazy/nvim-nio/lua/nio/tasks.lua:122: in function 'step'
	...s/javo/.local/share/nvim/lazy/nvim-nio/lua/nio/tasks.lua:150: in function 'run'
	/Users/javo/.config/nvim/lua/plugins/lsp.lua:360: in function </Users/javo/.config/nvim/lua/plugins/lsp.lua:359>
```

By  wrapping the `vim.cmd("write")` call in a `pcall()`, it will silently fail if the Tinker command is ran from a `[No Name]` buffer.
