### PR TITLE
Fix history provider not listening to the correct pattern

### DIFF
--- a/lua/laravel/providers/history_provider.lua
+++ b/lua/laravel/providers/history_provider.lua
@@ -19,7 +19,7 @@ function provider:boot(app)
 
   vim.api.nvim_create_autocmd({ "User" }, {
     group = group,
-    pattern = { "LaravelCommandRun" },
+    pattern = { require("laravel.events.command_run_event").name },
     callback = function(ev)
       app("history"):add(ev.data.job_id, ev.data.cmd, ev.data.args, ev.data.options)
     end,


### PR DESCRIPTION
On commit 995770e some changes were made to the events and the history provider had the wrong pattern so the history did not register any artisan/user commands; to be honest I'm not sure this is the way you would solve it but from what I tested this solves the commands not being recorded in the history.

https://github.com/user-attachments/assets/a99f7b2a-f654-4e92-bd71-497f0d59245c