### PR TITLE
Removes mb_strtolower aditional path

### DIFF
--- a/lua/laravel/php-templates/inertia.lua
+++ b/lua/laravel/php-templates/inertia.lua
@@ -4,7 +4,7 @@ echo json_encode([
     'page_paths' => collect(config('inertia.page_paths', config('inertia.testing.page_paths', [])))->flatMap(function($path) {
         $relativePath = LaraveNvim::relativePath($path);
 
-        return [$relativePath, mb_strtolower($relativePath)];
+        return [$relativePath];
     })->unique()->values(),
 ]);
 ]]


### PR DESCRIPTION
## Changes
Leaves only the relative paths explicitly defined on the `inertia.page_paths`


### Notes
On MacOS, due to case being a case-insensitive file system when 
```
  local paths = vim.tbl_filter(function(dir)
    local _, stat = nio.uv.fs_stat(dir)
    return stat ~= nil
  end, inertia.page_paths)
```
is ran on the `inertia_completion.lua@inertia_completion.complete` it would match on both of the values thus:
```
would go in: inertia.path_paths = { "resources/js/Pages", "resources/js/pages" }
would be resolved: path = { "resources/js/Pages", "resources/js/pages" }
```

I think that since on the `laravel/vs-code-extension` gets executed by node, they can consistently filter appropriately filter things out appropriately, but on our case we may be able to carry on by only using the explicitly defined paths