### PR TITLE
Fix for non escaped paths when using the Route Picker

### DIFF
--- a/lua/laravel/services/class_finder.lua
+++ b/lua/laravel/services/class_finder.lua
@@ -13,6 +13,8 @@ function class_finder:find(text)
     return {}, Error:new("No class name provided")
   end
 
+  local escaped_text = text:gsub("\\", "\\\\")
+
   local result, err = self.tinker:json(string.format(
     [[
     $text = "%s";
@@ -31,7 +33,7 @@ function class_finder:find(text)
         ]);
     }
   ]],
-    text
+    escaped_text
   ))
 
   if err then


### PR DESCRIPTION
Created a fix for issues when working on paths that have some kind of escaped character in them. For example Controllers\v1 causes errors. This fix has been tested and been shown to work locally for me.

My issue occurred when using the route picker and picking a path that would contain a nonescaped character like \n or \v.