### PR TITLE
fix: typo in resources picker

### DIFF
--- a/lua/laravel/commands/resources.lua
+++ b/lua/laravel/commands/resources.lua
@@ -2,11 +2,11 @@ local app = require("laravel.core.app")
 local nio = require("nio")
 
 return {
-  signature = "picker:resoruces",
-  description = "Open the resoruces picker",
+  signature = "picker:resources",
+  description = "Open the resources picker",
   handle = nio.create(function()
     ---@type laravel.managers.pickers_manager
     local pickers = app:make("pickers_manager")
-    pickers:run("resoruces")
+    pickers:run("resources")
   end, 1),
 }


### PR DESCRIPTION
This just fixes a small typo that was preventing the resources picker from opening. Thanks for this plugin!