### PR TITLE
fix: adds a simple result validation to prevent sending null to vim.json.decode

### DIFF
--- a/lua/laravel/services/code.lua
+++ b/lua/laravel/services/code.lua
@@ -57,6 +57,10 @@ function code:run(name)
   -- need to parse to remove the  START_OUTPUT and  END_OUTPUT
   result = result:match("__NEOVIM_LARAVEL_START_OUTPUT__%s*(.-)%s*__NEOVIM_LARAVEL_END_OUTPUT__")
 
+  if not result or result == "" then
+    return nil, Error:new("Invalid or empty PHP output while running code template: " .. name)
+  end
+
   return vim.json.decode(result, { luanil = { object = true } }), nil
   -- return result, nil
 end


### PR DESCRIPTION
It's just a commit that adds a simple validation for result. It was the solution I found to solve the problem I'm having and reported in:  #173 