### PR TITLE
Updates the models php template

### DIFF
--- a/lua/laravel/php-templates/models.lua
+++ b/lua/laravel/php-templates/models.lua
@@ -53,7 +53,11 @@ $models = new class($factory) {
 
     public function all()
     {
-        collect(glob(base_path('**/Models/*.php')))->each(fn($file) => include_once($file));
+        if (\Illuminate\Support\Facades\File::isDirectory(base_path('app/Models'))) {
+            collect(\Illuminate\Support\Facades\File::allFiles(base_path('app/Models')))
+                ->filter(fn(\Symfony\Component\Finder\SplFileInfo $file) => $file->getExtension() === 'php')
+                ->each(fn($file) => include_once($file));
+        }
 
         return collect(get_declared_classes())
             ->filter(fn($class) => is_subclass_of($class, \Illuminate\Database\Eloquent\Model::class))
@@ -154,8 +158,12 @@ $models = new class($factory) {
             ->toArray();
 
         $data['scopes'] = collect($reflection->getMethods())
-            ->filter(fn($method) =>!$method->isStatic() && ($method->getAttributes(\Illuminate\Database\Eloquent\Attributes\Scope::class) || ($method->isPublic() && str_starts_with($method->name, 'scope'))))
-            ->map(fn($method) => str($method->name)->replace('scope', '')->lcfirst()->toString())
+            ->filter(fn(\ReflectionMethod $method) => !$method->isStatic() && ($method->getAttributes(\Illuminate\Database\Eloquent\Attributes\Scope::class) || ($method->isPublic() && str_starts_with($method->name, 'scope'))))
+            ->map(fn(\ReflectionMethod $method) => [
+                "name" => str($method->name)->replace('scope', '')->lcfirst()->toString(),
+                "method" => $method->name,
+                "parameters" => collect($method->getParameters())->map($this->getScopeParameterInfo(...)),
+            ])
             ->values()
             ->toArray();
 
@@ -164,6 +172,84 @@ $models = new class($factory) {
         return [
             $className => $data,
         ];
+    }
+
+    protected function getScopeParameterInfo(\ReflectionParameter $parameter): array
+    {
+        $result = [
+            "name" => $parameter->getName(),
+            "type" => $this->typeToString($parameter->getType()),
+            "hasDefault" => $parameter->isDefaultValueAvailable(),
+            "isVariadic" => $parameter->isVariadic(),
+            "isPassedByReference" => $parameter->isPassedByReference(),
+        ];
+
+        if ($parameter->isDefaultValueAvailable()) {
+            $result['default'] = $this->defaultValueToString($parameter);
+        }
+
+        return $result;
+    }
+
+    protected function typeToString(?\ReflectionType $type): string
+    {
+        return match (true) {
+            $type instanceof \ReflectionNamedType => $this->namedTypeToString($type),
+            $type instanceof \ReflectionUnionType => $this->unionTypeToString($type),
+            $type instanceof \ReflectionIntersectionType => $this->intersectionTypeToString($type),
+            default => 'mixed',
+        };
+    }
+
+    protected function namedTypeToString(\ReflectionNamedType $type): string
+    {
+        $name = $type->getName();
+
+        if (! $type->isBuiltin() && ! in_array($name, ['self', 'parent', 'static'])) {
+            $name = '\\'.$name;
+        }
+
+        if ($type->allowsNull() && ! in_array($name, ['null', 'mixed', 'void'])) {
+            $name = '?'.$name;
+        }
+
+        return $name;
+    }
+
+    protected function unionTypeToString(\ReflectionUnionType $type): string
+    {
+        return implode('|', array_map(function (\ReflectionType $type) {
+            $result = $this->typeToString($type);
+
+            if ($type instanceof \ReflectionIntersectionType) {
+                return "({$result})";
+            }
+
+            return $result;
+        }, $type->getTypes()));
+    }
+
+    protected function intersectionTypeToString(\ReflectionIntersectionType $type): string
+    {
+        return implode('&', array_map($this->typeToString(...), $type->getTypes()));
+    }
+
+    protected function defaultValueToString(\ReflectionParameter $param): string
+    {
+        if ($param->isDefaultValueConstant()) {
+            return '\\'.$param->getDefaultValueConstantName();
+        }
+
+        $value = $param->getDefaultValue();
+
+        return match (true) {
+            is_null($value) => 'null',
+            is_numeric($value) => $value,
+            is_bool($value) => $value ? 'true' : 'false',
+            is_array($value) => '[]',
+            is_object($value) => 'new \\'.get_class($value),
+            default => "'{$value}'",
+        };
     }
 };
 


### PR DESCRIPTION
Updates the `lua/laravel/php-templates/models.lua` to match the latest from the [vs-code-extension](https://github.com/laravel/vs-code-extension/blob/main/php-templates/models.php)

## Notes
While test driving the model `_model_helpers.php`, noticed that the `scope` query methods would throw errors since the current template would return the following into 
```php
class User extends Authenticatable
{
    #[Scope]
    public function forZoro(Builder $query): void
    {
        $query->where('name', 'Zoro');
    }
}
```
into 
```json
...
            "scopes": ["forZoro"],
...
```

The same behavior would happen when there would be a `forName(Builder $query, $name)` where the parameters would be added to the doc block properly.

After upgrading to the latest template it would properly generate the expected format of 
```json
      "scopes": [
         {
          "name": "forName",
          "method": "forName",
          "parameters": [
            {
              "name": "query",
              "type": "\\Illuminate\\Database\\Eloquent\\Builder",
              "hasDefault": false,
              "isVariadic": false,
              "isPassedByReference": false
            },
            {
              "name": "name",
              "type": "mixed",
              "hasDefault": false,
              "isVariadic": false,
              "isPassedByReference": false
            }
          ]
        }
      ]
```