### PR TITLE
fix: prevent Lua gsub from interpreting % in PHP code

### DIFF
--- a/lua/laravel/services/code.lua
+++ b/lua/laravel/services/code.lua
@@ -98,7 +98,7 @@ function code:make_php_file(code, template)
   if not ok or type(tpl) ~= 'string' then
     error('Could not load PHP template: ' .. tostring(template))
   end
-  local output = tpl:gsub('__NVIM_LARAVEL_OUTPUT__', code)
+  local output = tpl:gsub('__NVIM_LARAVEL_OUTPUT__', function() return code end)
   local hash = md5.sumhexa(output)
   local fname = hash .. '.' .. template .. '.php'
   local full = dir .. fname


### PR DESCRIPTION
Fixes a bug where SQL wildcard patterns (e.g., `%example.net`) in PHP code would silently break when executed through tinker

## The Bug

When executing PHP queries containing `%` characters

```php
User::query()->where('email', 'like', '%example.net')->get();
```

The query would return **empty results** even though running the same query directly in `php artisan tinker` worked correctly.

**Root cause:** In `code:make_php_file()`, the line:

```lua
local output = tpl:gsub('__NVIM_LARAVEL_OUTPUT__', code)
```

Lua's `gsub` interprets `%` as a special character in the **replacement string** (for capture references like `%1`, `%2`). So `%example.net` → `%e` was being interpreted as a capture reference and getting mangled.

## The Fix

Use a function as the replacement argument, which makes `gsub` treat the return value as a literal string:

```lua
local output = tpl:gsub('__NVIM_LARAVEL_OUTPUT__', function() return code end)
```

This ensures any `%` characters in PHP code pass through unchanged.