### PR TITLE
docs: add vim.pack installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,72 @@ Using [Lazy.nvim](https://github.com/folke/lazy.nvim)
 }
 ```
 
+## Using `vim.pack` (Neovim 0.11+ built-in package manager)
+
+Add to your plugin specs (e.g., `lua/plugins/specs.lua`):
+```lua
+local gh = function(repo)
+  return "https://github.com/" .. repo
+end
+
+return {
+  -- dependencies
+  { src = gh("MunifTanjim/nui.nvim") },
+  { src = gh("nvim-lua/plenary.nvim") },
+  { src = gh("nvim-neotest/nvim-nio") },
+  -- laravel.nvim
+  { src = gh("adalessa/laravel.nvim") },
+}
+```
+
+Then bootstrap in your `init.lua`:
+```lua
+vim.pack.add(require("plugins.specs"))
+```
+
+Then create your setup file (e.g., `lua/plugins/setup/laravel.lua`):
+```lua
+local laravel = require("laravel")
+
+laravel.setup({
+  features = {
+    pickers = {
+      provider = "telescope", -- or "snacks" | "fzf-lua" | "ui-select"
+    },
+  },
+})
+
+vim.g.Laravel = laravel
+
+local function map(lhs, fn, desc)
+  vim.keymap.set("n", lhs, fn, { desc = desc })
+end
+
+map("<leader>ll", function() Laravel.pickers.laravel() end, "Laravel: Open Laravel Picker")
+map("<leader>la", function() Laravel.pickers.artisan() end, "Laravel: Open Artisan Picker")
+map("<leader>lr", function() Laravel.pickers.routes() end, "Laravel: Open Routes Picker")
+map("<leader>lm", function() Laravel.pickers.make() end, "Laravel: Open Make Picker")
+map("<leader>lc", function() Laravel.pickers.commands() end, "Laravel: Open Commands Picker")
+map("<leader>lo", function() Laravel.pickers.resources() end, "Laravel: Open Resources Picker")
+map("<leader>lt", function() Laravel.commands.run("actions") end, "Laravel: Open Actions Picker")
+map("<leader>lu", function() Laravel.commands.run("hub") end, "Laravel Artisan hub")
+map("<leader>lh", function() Laravel.run("artisan docs") end, "Laravel: Open Documentation")
+map("<c-g>", function() Laravel.commands.run("view:finder") end, "Laravel: Open View Finder")
+map("<leader>lp", function() Laravel.commands.run("command_center") end, "Laravel: Open Command Center")
+
+map("gf", function()
+  local ok, res = pcall(function()
+    if Laravel.app("gf").cursorOnResource() then
+      return "<cmd>lua Laravel.commands.run('gf')<cr>"
+    end
+  end)
+  if not ok or not res then
+    return "gf"
+  end
+  return res
+end, "Laravel: Go to resource", { expr = true, noremap = true })
+```
+
 ## Configuration
 The configuration is extense and recommend look [here](lua/laravel/options/default.lua)
 


### PR DESCRIPTION
## Summary
Adds installation instructions for Neovim 0.11+ built-in package manager (`vim.pack`) to the README.

## Changes
- Added new section "Using \`vim.pack\` (Neovim 0.11+ built-in package manager)" after the Lazy.nvim section
- Included plugin specs example showing how to add laravel.nvim and its dependencies
- Added bootstrap example for loading specs
- Included complete setup file example with keymaps and configuration

This provides users with a native alternative to plugin managers like Lazy.nvim, which is built into Neovim 0.11+.