### PR TITLE
fix(extensions): gate for registering and booting only enabled extensions

### DIFF
--- a/lua/laravel/providers/extensions_provider.lua
+++ b/lua/laravel/providers/extensions_provider.lua
@@ -32,10 +32,10 @@ function extension_provider.register(app)
       return
     end
     local opts = app("laravel.services.config").get("extensions." .. ext.name, {})
-    if provider.register then
+    if opts.enable and provider.register then
       local ok, res = pcall(function()
         provider.register(app, opts)
-        ext.registered = true;
+        ext.registered = true
       end)
 
       if not ok then
@@ -55,10 +55,10 @@ function extension_provider.boot(app)
       return
     end
     local opts = app("laravel.services.config").get("extensions." .. ext.name, {})
-    if provider.boot then
+    if opts.enable and provider.boot then
       local ok, res = pcall(function()
         provider.boot(app, opts)
-        ext.booted = true;
+        ext.booted = true
       end)
 
       if not ok then


### PR DESCRIPTION
With one of latest refactors to how extensions are loaded, it seems that the check for the `enable` config key was removed by accident. Thus, all extensions were loaded (registered and booted) even though configured with `enable = false`.