### PR TITLE
prevent error caused by missing vendor dir

### DIFF
--- a/lua/laravel/services/code.lua
+++ b/lua/laravel/services/code.lua
@@ -4,7 +4,8 @@ local Error = require("laravel.utils.error")
 local md5 = require("laravel.utils.md5")
 local app = require("laravel.core.app")
 
-local dir = "vendor/nvim-laravel/"
+local vendor_dir = "vendor"
+local dir = vendor_dir .. "/nvim-laravel/"
 
 ---@class laravel.services.code
 ---@field api laravel.services.api
@@ -86,6 +87,13 @@ function codeService:make_php_file(code, template)
   local full = dir .. fname
   local _, file_stats = nio.uv.fs_stat(full)
   if not (file_stats and file_stats.size > 0) then
+    local _, vendor_dir_stats = nio.uv.fs_stat(vendor_dir)
+    if not vendor_dir_stats then
+      local _, ok = nio.uv.fs_mkdir(vendor_dir, 493) -- 0755
+      if not ok then
+        error("Could not create directory " .. vendor_dir)
+      end
+    end
     local _, dir_stats = nio.uv.fs_stat(dir)
     if not dir_stats then
       local _, ok = nio.uv.fs_mkdir(dir, 493) -- 0755


### PR DESCRIPTION
### Problem
Directory `vendor/laravel-nvim` fails to be created if directory `vendor` does not exist.

This PR addresses issue #194.

### Error displayed
```
   Error  11:29:29 msg_show.lua_error Lua callback:
...local/share/nvim-lazyvim/lazy/nvim-nio/lua/nio/tasks.lua:100: Async task failed without callback: The coroutine failed with this message: 
...-lazyvim/lazy/laravel.nvim/lua/laravel/services/code.lua:93: Could not create directory for php files: vendor/nvim-laravel/
stack traceback:
	[C]: in function 'error'
	...-lazyvim/lazy/laravel.nvim/lua/laravel/services/code.lua:93: in function 'make_php_file'
	...-lazyvim/lazy/laravel.nvim/lua/laravel/services/code.lua:31: in function 'fromTemplate'
	.../lazy/laravel.nvim/lua/laravel/loaders/models_loader.lua:31: in function 'load'
	.../laravel.nvim/lua/laravel/providers/laravel_provider.lua:64: in function <.../laravel.nvim/lua/laravel/providers/laravel_provider.lua:63>
stack traceback:
	[C]: in function 'error'
	...local/share/nvim-lazyvim/lazy/nvim-nio/lua/nio/tasks.lua:100: in function 'close_task'
	...local/share/nvim-lazyvim/lazy/nvim-nio/lua/nio/tasks.lua:122: in function 'cb'
	...local/share/nvim-lazyvim/lazy/nvim-nio/lua/nio/tasks.lua:183: in function <...local/share/nvim-lazyvim/lazy/nvim-nio/lua/nio/tasks.lua:182>
	[C]: in function 'nvim_exec_autocmds'
	...m-lazyvim/lazy/lazy.nvim/lua/lazy/core/handler/event.lua:161: in function <...m-lazyvim/lazy/lazy.nvim/lua/lazy/core/handler/event.lua:160>
	[C]: in function 'xpcall'
	...share/nvim-lazyvim/lazy/lazy.nvim/lua/lazy/core/util.lua:135: in function 'try'
	...m-lazyvim/lazy/lazy.nvim/lua/lazy/core/handler/event.lua:160: in function 'trigger'
	...m-lazyvim/lazy/lazy.nvim/lua/lazy/core/handler/event.lua:89: in function <...m-lazyvim/lazy/lazy.nvim/lua/lazy/core/handler/event.lua:72>
	[C]: in function 'nvim_cmd'
	...rew/Cellar/neovim/0.12.3/share/nvim/runtime/filetype.lua:28: in function <...rew/Cellar/neovim/0.12.3/share/nvim/runtime/filetype.lua:27>
	[C]: in function 'pcall'
	vim/_core/shared:1648: in function <vim/_core/shared:1628>
	[C]: in function '_with'
	...rew/Cellar/neovim/0.12.3/share/nvim/runtime/filetype.lua:27: in function <...rew/Cellar/neovim/0.12.3/share/nvim/runtime/filetype.lua:10>
	[C]: in function 'nvim_exec2'
	[string "vim/_core/editor"]:355: in function 'cmd'
	...m-lazyvim/lazy/snacks.nvim/lua/snacks/picker/actions.lua:139: in function 'jump'
	...m-lazyvim/lazy/snacks.nvim/lua/snacks/picker/actions.lua:42: in function <...m-lazyvim/lazy/snacks.nvim/lua/snacks/picker/actions.lua:41>
	```
	
### Solution
The fix checks for the existence of directory `vendor` and creates it if missing, before attempting to create directory `vendor/laravel-nvim`.
